### PR TITLE
If setting alternatives, ensure /usr/bin symlinks exist

### DIFF
--- a/manifests/java17.pp
+++ b/manifests/java17.pp
@@ -67,6 +67,16 @@ class java_artisanal::java17 (
       alternatives { $cmd:
         path => $dest,
       }
+
+      ## If something removes a /usr/bin symlink managed by alternatives,
+      ## but does not change the preferred alternative,
+      ## the above by itself does not recreate the /usr/bin link.
+      ## Eg it seems as if updates to the system java-11-openjdk-headless
+      ## rpm can do this (see postinstall script).
+      file { $src:
+        ensure => link,
+        target => "/etc/alternatives/${cmd}",
+      }
     }
   }
 }


### PR DESCRIPTION
As things stand, if something deletes a /usr/bin/X -> /etc/alternatives/X symlink, this module does not recreate it.
It seemed this happened on many hosts recently when the system rpm java-11-openjdk-headless was updated.
That package has a complicated post-install script that manipulates alternatives.